### PR TITLE
新しい unidic-cwj 内の lex.csv への対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+lex*.csv
+migemo-dict

--- a/build.py
+++ b/build.py
@@ -1,6 +1,7 @@
 import re
 import csv
 from typing import Optional
+from pathlib import Path
 
 # カタカナをひらがなに変換する
 def kata2hira(hira: str) -> str:
@@ -56,31 +57,32 @@ if __name__ == '__main__':
             dictionary[key] = words
 
     # UniDicのファイルを読み込み
-    with open('lex_3_1.csv', encoding='utf-8') as f:
-        reader = csv.reader(f, delimiter=',')
-        for row in reader:
-            word = row[0]
-            reading = row[24]
-            pair = convertKanjiHiraganaWord(word, reading)
-            if pair:
-                kana = pair[0]
-                kanji = pair[1]
-                if kana in dictionary:
-                    dictionary[kana].append(kanji)
-                else:
-                    dictionary[kana] = [kanji]
-            pair = convertAlphabeticWord(word, reading)
-            if pair:
-                kana = pair[0]
-                kanji = pair[1]
-                if kana in dictionary:
-                    dictionary[kana].append(kanji)
-                else:
-                    dictionary[kana] = [kanji]
-                if kanji in dictionary:
-                    dictionary[kanji].append(kana)
-                else:
-                    dictionary[kanji] = [kana]
+    for path in Path(".").glob("lex*.csv"):
+        with open(path, encoding='utf-8') as f:
+            reader = csv.reader(f, delimiter=',')
+            for row in reader:
+                word = row[0]
+                reading = row[24]
+                pair = convertKanjiHiraganaWord(word, reading)
+                if pair:
+                    kana = pair[0]
+                    kanji = pair[1]
+                    if kana in dictionary:
+                        dictionary[kana].append(kanji)
+                    else:
+                        dictionary[kana] = [kanji]
+                pair = convertAlphabeticWord(word, reading)
+                if pair:
+                    kana = pair[0]
+                    kanji = pair[1]
+                    if kana in dictionary:
+                        dictionary[kana].append(kanji)
+                    else:
+                        dictionary[kana] = [kanji]
+                    if kanji in dictionary:
+                        dictionary[kanji].append(kana)
+                    else:
+                        dictionary[kanji] = [kana]
 
     # 出力
     sortedKeys = sorted(dictionary.keys())


### PR DESCRIPTION
`unidic-cwj-202302_full` 以降では、それ以前とは `lex*.csv` ファイルの命名方法が異なるようです

- `unidic-cwj-3.1.1-full` では `lex_3_1.csv`
- `unidic-cwj-202302_full` では `lex.csv`

どちらにも対応できるよう、ワイルドカードでのファイル検索を行うように変更しました
